### PR TITLE
feat: support for custom actions

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,16 +1,16 @@
 local M = {}
 
-local wezterm = require('wezterm')
+local wezterm = require("wezterm")
 local act = wezterm.action
 
-local function startswith(str, prefix)
+function string.startswith(str, prefix)
     return string.sub(str, 1, string.len(prefix)) == prefix
 end
 
 local function extract_filename(uri)
-    local start, match_end = uri:find("$EDITOR:");
+    local start, match_end = uri:find("$EDITOR:")
     if start == 1 then
-        return uri:sub(match_end+1)
+        return uri:sub(match_end + 1)
     end
 
     return nil
@@ -31,45 +31,64 @@ local function get_extension(filename)
 end
 
 local function basename(s)
-    return string.gsub(s, '(.*[/\\])(.*)', '%2')
+    return string.gsub(s, "(.*[/\\])(.*)", "%2")
 end
 
-function M.Open_with_hx(window, pane, url, opts)
+function M.open_with_hx(window, pane, url, opts)
     local filename = extract_filename(url)
-    if not (filename and is_editable(filename, opts.text_extensions)) then
+    if not filename then
+        wezterm.log_error(url .. " is not a valid filename")
+        return
+    end
+    if not is_editable(filename, opts.text_extensions) then
+        wezterm.log_info(filename .. " is not editable")
         return -- let default action handle it
     end
 
-    wezterm.log_info('editable')
+    wezterm.log_info(filename .. " is editable")
     if get_extension(filename) == "rs" then
         local pwd = string.gsub(tostring(pane:get_current_working_dir()), "file://.-(/.+)", "%1")
         filename = pwd .. "/" .. filename
     end
 
     local hx_pane = pane:tab():get_pane_direction(opts.direction)
-    wezterm.log_info("fg process: " .. hx_pane:get_foreground_process_name())
-    if hx_pane == nil then
-        local action = act{
-            SplitPane={
+    if not hx_pane then
+        local action = act({
+            SplitPane = {
                 direction = opts.direction,
-                command = { args = { 'hx', filename } }
-            };
-        };
-        window:perform_action(action, pane);
-        pane:tab():get_pane_direction(opts.direction).activate()
-    elseif basename(hx_pane:get_foreground_process_name()) == "hx" then
-        wezterm.log_info('process = hx')
-        local action = act.SendString(':open ' .. filename .. '\r')
-        window:perform_action(action, hx_pane);
-        hx_pane:activate()
+                command = { args = { "hx", filename } },
+            },
+        })
+        window:perform_action(action, pane)
+        hx_pane = pane:tab():get_pane_direction(opts.direction).activate()
     else
-        local action = act.SendString('hx ' .. filename .. '\r')
-        wezterm.log_info('action: ' .. action)
-        window:perform_action(action, hx_pane);
-        hx_pane:activate()
+        local process = basename(hx_pane:get_foreground_process_name())
+        local command
+        if process == "hx" then
+            command = ":open " .. filename .. "\r\n"
+        else
+            command = "hx " .. filename .. "\r\n"
+        end
+        wezterm.log_info("process: " .. process .. ", action: " .. command)
+        local action = act.SendString(command)
+        window:perform_action(action, hx_pane)
     end
+    hx_pane:activate()
+
     -- prevent the default action from opening in a browser
-    return false
+end
+
+M.filters = {}
+function M.filters.startswith(str)
+    return function(selection)
+        return selection:startswith(str)
+    end
+end
+
+function M.filters.match(str)
+    return function(selection)
+        return selection:match(str)
+    end
 end
 
 function M.apply_to_config(config, opts)
@@ -78,68 +97,106 @@ function M.apply_to_config(config, opts)
     end
     opts.key = opts.key or "s"
     opts.mods = opts.mods or "CMD|SHIFT"
-    opts.text_extensions = opts.text_extensions or {
-        md = true,
-        c = true,
-        go = true,
-        scm = true,
-        rkt = true,
-        rs = true,
-        java = true,
-    }
-    opts.patterns = opts.patterns or {
-        'https?://\\S+',
-        '^/[^/\r\n]+(?:/[^/\r\n]+)*:\\d+:\\d+',
-        '[^\\s]+\\.rs:\\d+:\\d+',
-        'rustc --explain E\\d+',
-        '[^\\s]+\\.go:\\d+',
-        '[^\\s]+\\.go:\\d+:\\d+',
-        '[^\\s]+\\.java:\\[\\d+,\\d+\\]',
-        '[^{]*{.*}',
-    }
+    opts.text_extensions = opts.text_extensions
+        or {
+            md = true,
+            c = true,
+            go = true,
+            scm = true,
+            rkt = true,
+            rs = true,
+            java = true,
+        }
+    opts.patterns = opts.patterns
+        or {
+            "https?://\\S+",
+            "^/[^/\r\n]+(?:/[^/\r\n]+)*:\\d+:\\d+",
+            "[^\\s]+\\.rs:\\d+:\\d+",
+            "rustc --explain E\\d+",
+            "[^\\s]+\\.go:\\d+",
+            "[^\\s]+\\.go:\\d+:\\d+",
+            "[^\\s]+\\.java:\\[\\d+,\\d+\\]",
+            "[^{]*{.*}",
+        }
+    opts.actions = opts.actions
+        or {
+            {
+                filter = M.filters.startswith("http"),
+                action = function(_, _, selection, _)
+                    wezterm.open_with(selection)
+                end,
+            },
+            {
+                filter = M.filters.startswith("rustc --explain"),
+                action = function(window, pane, selection, _)
+                    local code = selection:match("(%S+)$")
+                    window:perform_action(
+                        act.SplitPane({
+                            direction = "Right",
+                            command = {
+                                args = {
+                                    "/bin/sh",
+                                    "-c",
+                                    "rustc --explain " .. code .. " | mdcat -p",
+                                },
+                            },
+                        }),
+                        pane
+                    )
+                end,
+            },
+            {
+                filter = M.filters.match("[^{]*{.*}"),
+                action = function(window, pane, selection, _)
+                    local json = selection:match("{.*}")
+                    local cmd = "echo '" .. json .. "' | jq -C . | less -R"
+                    window:perform_action(
+                        act.SplitPane({
+                            direction = "Right",
+                            command = { args = { "/bin/sh", "-c", cmd } },
+                        }),
+                        pane
+                    )
+                end,
+            },
+            {
+                filter = M.filters.match("[^:%s]+%.java):%[(%d+),%d+%]"),
+                action = function(window, pane, selection, opts)
+                    local file, line = selection:match("([^:%s]+%.java):%[(%d+),%d+%]")
+                    if file and line then
+                        selection = "$EDITOR:" .. file .. ":" .. line
+                    else
+                        selection = "$EDITOR:" .. selection
+                    end
+                    return M.open_with_hx(window, pane, selection, opts)
+                end,
+            },
+        }
     opts.direction = opts.direction or "Up"
 
     config.keys = config.keys or {}
     table.insert(config.keys, {
         key = opts.key,
         mods = opts.mods,
-        action = act.QuickSelectArgs {
-            label = 'open url',
+        action = act.QuickSelectArgs({
+            label = "open url",
             patterns = opts.patterns,
             action = wezterm.action_callback(function(window, pane)
                 local selection = window:get_selection_text_for_pane(pane)
-                wezterm.log_info('opening: ' .. selection)
-                if startswith(selection, "http") then
-                    wezterm.open_with(selection)
-                elseif startswith(selection, "rustc --explain") then
-                    local code = selection:match("(%S+)$")
-                    window:perform_action(act.SplitPane {
-                        direction = 'Right',
-                        command = {
-                            args = {
-                                '/bin/sh', '-c',
-                                'rustc --explain ' .. code .. ' | mdcat -p',
-                            }
-                        }
-                    }, pane)
-                elseif selection:match('[^{]*{.*}') then
-                    local json = selection:match("{.*}")
-                    local cmd = "echo '" .. json .. "' | jq -C . | less -R"
-                    window:perform_action(act.SplitPane {
-                        direction = 'Right',
-                        command = { args = { '/bin/sh', '-c', cmd } }
-                    }, pane)
-                else
-                    local file, line = selection:match('([^:%s]+%.java):%[(%d+),%d+%]')
-                    if file and line then
-                        selection = "$EDITOR:" .. file .. ":" .. line
-                    else
-                        selection = "$EDITOR:" .. selection
+                wezterm.log_info("opening: " .. selection)
+
+                -- use custom action
+                for _, custom in ipairs(opts.actions) do
+                    if custom.filter(selection) then
+                        return custom.action(window, pane, selection, opts)
                     end
-                    return M.Open_with_hx(window, pane, selection, opts)
                 end
-            end)
-        }
+
+                -- if not suitable custom action, fallback to default
+                selection = "$EDITOR:" .. selection
+                return M.open_with_hx(window, pane, selection, opts)
+            end),
+        }),
     })
 end
 


### PR DESCRIPTION
This PR enable the user to write filter and run custom action on selection
for example (my personal config)

```lua

local opts = {
    text_extensions = {
        md = true,
        c = true,
        h = true,
        hpp = true,
        hxx = true,
        inl = true,
        tpp = true,
        cxx = true,
        cc = true,
        cpp = true,
        cppm = true,
        mpp = true,
        ixx = true,
        go = true,
        scm = true,
        rkt = true,
        rs = true,
        java = true,
        lua = true,
    },
    key = 'F2',
    mods = '',
    patterns = {
        [[https?://\S+]],
        [[@programdir[^\r\n\s]*:\d+(:\d+)?]],
        [[[^\r\n\s]*:\d+:\d+]],
    },
    direction = 'Left',
    actions = {
        {
            filter = quickselect.filters.startswith('http'),
            action = function(_, _, selection, _) wezterm.open_with(selection) end,
        },
        {
            filter = quickselect.filters.startswith('@programdir'),
            action = function(window, pane, selection, opts)
                selection = selection:sub(#'@programdir' + 1)
                selection = (is_windows() and 'F:/repos/xmake/xmake' or '~/development/xmake') .. selection
                selection = '$EDITOR:' .. selection
                return quickselect.open_with_hx(window, pane, selection, opts)
            end,
        },
    },
}
quickselect.apply_to_config(config, opts)

```

if no filter match, it fallback to the default action (try to open with helix directly)
