### PR TITLE
Remove debug log, that causes error

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -47,7 +47,6 @@ function M.Open_with_hx(window, pane, url, opts)
     end
 
     local hx_pane = pane:tab():get_pane_direction(opts.direction)
-    wezterm.log_info("fg process: " .. hx_pane:get_foreground_process_name())
     if hx_pane == nil then
         local action = act{
             SplitPane={


### PR DESCRIPTION
If the pane is not found, then the line removed by this pull request causes an error and the plugin won't try to create a new split.